### PR TITLE
Add more fields from the twitter API in the UsersStream schema

### DIFF
--- a/tap_twitter/schemas/users.schema.json
+++ b/tap_twitter/schemas/users.schema.json
@@ -159,6 +159,42 @@
           ]
         }
       }
+    },
+    "profile_image_url": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "username": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "verified": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "description": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "url": {
+      "type": [
+        "null",
+        "string"
+      ]
     }
   }
 }


### PR DESCRIPTION
Thanks a lot for open-sourcing this tap !

I noticed that a couple values in `user_fields` (UsersStream class) do not appear in the Users JSON schema. This makes it impossible to select and extract fields such as the `username`, `name`, etc from the tap, even though they are available from the twitter API and they are fetched by the tap.

This PR adds these additional fields to the json schema to fix it. In case you plan on maintaining this tap and (eventually) adding it to the meltano hub, do you think this could be merged into your repo?