### PR TITLE
fix key error when no tweets returned

### DIFF
--- a/tap_twitter/streams.py
+++ b/tap_twitter/streams.py
@@ -54,7 +54,7 @@ class TweetsStream(TwitterStream):
             users_lookup = {user["id"]: user for user in record["includes"]["users"]}
         else:
             users_lookup = None
-        for i, tweet in enumerate(record["data"]):
+        for i, tweet in enumerate(record.get("data", [])):
             if users_lookup:
                 tweet["expansion__author_id"] = users_lookup[tweet["author_id"]]
             else:


### PR DESCRIPTION
Closes https://github.com/voxmedia/tap-twitter/issues/3

I got a KeyError when I didnt get any recent tweets back from the API. This fixes that so it just continues if no data is returned.

@prratek @hkuffel let me know what you think!